### PR TITLE
Fixing Fib.ts 

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This was done by simply adding a parameter and return type, both of number, to the function. This was tested by running the npm run tests. This issue was rather simple to debug as the lint tests explained that the two function calls cannot be added because they're of type 'any'. Giving a return type of number fixes this. Adding a parameter type also ensures additional type safety. 